### PR TITLE
[#175575134] Audit logs table

### DIFF
--- a/GetBPDCitizen/handler.ts
+++ b/GetBPDCitizen/handler.ts
@@ -93,7 +93,7 @@ export function GetBPDCitizenHandler(
       publicRsaCertificate,
       requestFiscalCode =>
         insertOrReplaceEntity({
-          AuthLevel: "Admin" as "Admin",
+          AuthLevel: "Admin",
           Citizen: requestFiscalCode,
           OperationName: "GetBPDCitizen",
           PartitionKey: _.oid, // Can we use email?

--- a/GetBPDTransactions/index.ts
+++ b/GetBPDTransactions/index.ts
@@ -3,6 +3,7 @@ import * as passport from "passport";
 import * as winston from "winston";
 
 import { Context } from "@azure/functions";
+import { TableService } from "azure-storage";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -12,11 +13,16 @@ import { Transaction } from "../models/transaction";
 import { getRepository, IPostgresConnectionParams } from "../utils/database";
 import { GetBPDTransactions } from "./handler";
 
+import { GetInsertOrReplaceEntity } from "../utils/audit_logs";
 import { getConfigOrThrow } from "../utils/config";
 import { GetOAuthVerifier } from "../utils/middleware/oauth_adb2c";
 import { setupBearerStrategy } from "../utils/strategy/bearer_strategy";
 
 const config = getConfigOrThrow();
+
+const tableService = new TableService(
+  config.DASHBOARD_STORAGE_CONNECTION_STRING
+);
 
 const postgresConfig: IPostgresConnectionParams = {
   database: config.POSTGRES_DB_NAME,
@@ -60,6 +66,7 @@ app.get(
   GetOAuthVerifier(passportAuthenticator, config.ADB2C_POLICY_NAME),
   GetBPDTransactions(
     getRepository(postgresConfig, Transaction),
+    GetInsertOrReplaceEntity(tableService, config.DASHBOARD_LOGS_TABLE_NAME),
     config.JWT_SUPPORT_TOKEN_PUBLIC_RSA_CERTIFICATE
   )
 );

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -21,5 +21,9 @@ export const context = ({
     verbose: jest.fn().mockImplementation(console.log),
     // tslint:disable-next-line: no-console
     warn: jest.fn().mockImplementation(console.log)
+  },
+  // tslint:disable-next-line: object-literal-sort-keys
+  executionContext: {
+    invocationId: "123456"
   }
 } as unknown) as Context;

--- a/env.example
+++ b/env.example
@@ -2,6 +2,7 @@ COMPOSE_PROJECT_NAME=io-fn-backoffice
 
 FUNCTIONS_WORKER_RUNTIME=node
 DASHBOARD_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
+DASHBOARD_LOGS_TABLE_NAME=dashboard_audit_logs
 FUNCTIONS_V2_COMPATIBILITY_MODE=false
 
 # needed to connect to cosmosdb server

--- a/utils/__tests__/audit_logs.test.ts
+++ b/utils/__tests__/audit_logs.test.ts
@@ -1,0 +1,61 @@
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import {
+  IResponseSuccessJson,
+  ResponseSuccessJson
+} from "italia-ts-commons/lib/responses";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+import { AuditLogTableRow, withAudit } from "../audit_logs";
+
+const param1 = "1" as NonEmptyString;
+const param2 = "AAABBB01C02D345E" as FiscalCode;
+
+const mockInsertOrReplaceEntity = jest
+  .fn()
+  .mockImplementation(() => taskEither.of(void 0));
+const mockHttpHandler = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve(ResponseSuccessJson({}))) as (
+  p1: typeof param1,
+  p2: typeof param2
+) => Promise<IResponseSuccessJson<unknown>>;
+const aFiscalCode = "AAABBB01C02D345E" as FiscalCode;
+const anAuditLog: AuditLogTableRow = {
+  AuthLevel: "Admin",
+  Citizen: aFiscalCode,
+  OperationName: "GetBPDCitizen",
+  PartitionKey: "aPartitionKey" as NonEmptyString,
+  RowKey: "aRowKey" as NonEmptyString
+};
+
+describe("withAudit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call the function handler with the same params if insertOrReplaceEntity success", async () => {
+    await withAudit(mockInsertOrReplaceEntity)(
+      mockHttpHandler,
+      () => anAuditLog
+    )(param1, param2);
+    expect(mockInsertOrReplaceEntity).toHaveBeenNthCalledWith(1, anAuditLog);
+    expect(mockHttpHandler).toHaveBeenNthCalledWith(1, param1, param2);
+  });
+
+  it("should return a ResponseErrorInternal if insertOrReplaceEntity fail", async () => {
+    const expectedError = new Error("Error logging the action");
+    mockInsertOrReplaceEntity.mockImplementationOnce(() =>
+      fromLeft(expectedError)
+    );
+    const response = await withAudit(mockInsertOrReplaceEntity)(
+      mockHttpHandler,
+      () => anAuditLog
+    )(param1, param2);
+    expect(mockInsertOrReplaceEntity).toHaveBeenNthCalledWith(1, anAuditLog);
+    expect(mockHttpHandler).toBeCalledTimes(0);
+    expect(response).toEqual({
+      apply: expect.any(Function),
+      detail: `Internal server error: ${expectedError.message}`,
+      kind: "IResponseErrorInternal"
+    });
+  });
+});

--- a/utils/audit_logs.ts
+++ b/utils/audit_logs.ts
@@ -1,8 +1,10 @@
-import { TaskEither } from "fp-ts/lib/TaskEither";
+import { TableService } from "azure-storage";
+import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 
 const AuditLogTableRowR = t.interface({
+  AuthLevel: t.union([t.literal("Admin"), t.literal("Support")]),
   OperationName: t.union([
     t.literal("GetBPDCitizen"),
     t.literal("GetBPDTransactions")
@@ -22,3 +24,20 @@ export type AuditLogTableRow = t.TypeOf<typeof AuditLogTableRow>;
 export type InsertOrReplaceEntity = (
   entity: AuditLogTableRow
 ) => TaskEither<Error, unknown>;
+
+export const GetInsertOrReplaceEntity = (
+  tableService: TableService,
+  tableName: NonEmptyString
+): InsertOrReplaceEntity => (entity: AuditLogTableRow) =>
+  tryCatch<Error, unknown>(
+    () =>
+      new Promise((resolve, reject) =>
+        tableService.insertOrReplaceEntity(tableName, entity, (err, result) => {
+          if (err) {
+            return reject(err);
+          }
+          return resolve(result);
+        })
+      ),
+    err => err as Error
+  );

--- a/utils/audit_logs.ts
+++ b/utils/audit_logs.ts
@@ -1,6 +1,6 @@
 import { TableService } from "azure-storage";
 import { toError } from "fp-ts/lib/Either";
-import { taskEither } from "fp-ts/lib/TaskEither";
+import { taskEither, taskify } from "fp-ts/lib/TaskEither";
 import { TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import {
@@ -36,18 +36,9 @@ export const GetInsertOrReplaceEntity = (
   tableService: TableService,
   tableName: NonEmptyString
 ): InsertOrReplaceEntity => (entity: AuditLogTableRow) =>
-  tryCatch<Error, unknown>(
-    () =>
-      new Promise((resolve, reject) =>
-        tableService.insertOrReplaceEntity(tableName, entity, (err, result) => {
-          if (err) {
-            return reject(err);
-          }
-          return resolve(result);
-        })
-      ),
-    err => err as Error
-  );
+  taskify<Error, unknown>(cb =>
+    tableService.insertOrReplaceEntity(tableName, entity, cb)
+  )();
 
 /**
  * Augment an http handler to trace its execution

--- a/utils/audit_logs.ts
+++ b/utils/audit_logs.ts
@@ -1,0 +1,24 @@
+import { TaskEither } from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+
+const AuditLogTableRowR = t.interface({
+  OperationName: t.union([
+    t.literal("GetBPDCitizen"),
+    t.literal("GetBPDTransactions")
+  ]),
+  PartitionKey: NonEmptyString,
+  RowKey: NonEmptyString
+});
+
+const AuditLogTableRowO = t.partial({
+  Citizen: FiscalCode
+});
+
+const AuditLogTableRow = t.intersection([AuditLogTableRowO, AuditLogTableRowR]);
+
+export type AuditLogTableRow = t.TypeOf<typeof AuditLogTableRow>;
+
+export type InsertOrReplaceEntity = (
+  entity: AuditLogTableRow
+) => TaskEither<Error, unknown>;

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -23,6 +23,9 @@ export const IConfig = t.interface({
   ADB2C_POLICY_NAME: NonEmptyString,
   ADB2C_TENANT_NAME: NonEmptyString,
 
+  DASHBOARD_LOGS_TABLE_NAME: NonEmptyString,
+  DASHBOARD_STORAGE_CONNECTION_STRING: NonEmptyString,
+
   ADB2C_CONFIG: t.any // TODO: Define the ADB2C_CONFIG type
 });
 

--- a/utils/middleware/__tests__/citizen_id.test.ts
+++ b/utils/middleware/__tests__/citizen_id.test.ts
@@ -1,0 +1,66 @@
+import { Request } from "express";
+import { left, right } from "fp-ts/lib/Either";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+import { SupportToken } from "../../../generated/definitions/SupportToken";
+import { RequestCitizenToFiscalCode } from "../citizen_id";
+
+const aFiscalCode = "AAABBB01C02D345D" as FiscalCode;
+
+const aPublicRsaCert = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCc3FR1mjQDrhvaDF8UpdtQQknh
+MAyxT1o6eCwWIiF+ZHsnnnn8XI++V11+uqSlRlh9gamt4XKqc8/4vKTKzxBYJPV/
+TuJDDBC1kbs6SGpqbMjnHk4hUXeSlxbvuksmnwEzmT7u9jYlCj5Zjmr+pBLKBoTk
+FmprTzaax++spskX3QIDAQAB
+-----END PUBLIC KEY-----` as NonEmptyString;
+
+const aSupportToken = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXNjYWxDb2RlIjoiQUFBQkJCMDFDMDJEMzQ1RCIsImlhdCI6MTYwNTU0NzU3NywiZXhwIjo4NTE3NTQ3NTc3LCJpc3MiOiJpby1iYWNrZW5kIiwianRpIjoiMDFFUTkxRk1NMTg4WUJNQks3WEZCRzdZQUoifQ.jvj2JEtxHhyFZJbzdeFfymyEEOhD4FPBm2wjNwStWMFqbD8B8CuKEAN_fl6tBrASdI0ZW2XfQujP_TejMFiAjvf696FZKUIyIJo58iOb0nfyRwTCCWUYuyFgkvVMnuMSo47rzp7LUSYx8VUaqz5pJLK3p8w9C6Q-yxrvxGJOZ6M` as SupportToken;
+const anInvalidSupportToken = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXNjYWxDb2RlIjoiQUFBQkJCMDFDMDJEMzQ1RCIsImlhdCI6MTYwNTU0NzYzOCwiZXhwIjoxNjA1NTQ3NjM5LCJpc3MiOiJpby1iYWNrZW5kIiwianRpIjoiMDFFUTkxSEZaTUdGWkdFODUzTlg0TjIwTjYifQ.ENAJhnQB19jUKDYXyvf9LIps9tsRMGUIhsYKyBx8KQbhytKBzRBYaCskuvkHQbEE-CdK2kD66RoQIeg3-ulgA6uFe1aPrsAVS9sbxHKaz_xgHbB6MmyPiRYF9vuv-HsiVHLcL-XNOtczDmGdAsBz-uugeMkk2BjXqR2hf7hgP5Y` as SupportToken;
+
+const mockHeader = jest.fn();
+const mockRequest = ({
+  header: mockHeader
+} as unknown) as Request;
+
+describe("RequestCitizenToFiscalCode", () => {
+  it("should succeded if the header contain a plain fiscal code", async () => {
+    mockHeader.mockImplementationOnce(() => aFiscalCode);
+    const response = await RequestCitizenToFiscalCode(aPublicRsaCert)(
+      mockRequest
+    );
+    expect(response).toEqual(right(aFiscalCode));
+  });
+  it("should extract a fiscalCode from a valid JWT provided in header", async () => {
+    mockHeader.mockImplementationOnce(() => aSupportToken);
+    const response = await RequestCitizenToFiscalCode(aPublicRsaCert)(
+      mockRequest
+    );
+    expect(response).toEqual(right(aFiscalCode));
+  });
+  it("should return a Validation error if the header is empty", async () => {
+    mockHeader.mockImplementationOnce(() => undefined);
+    const response = await RequestCitizenToFiscalCode(aPublicRsaCert)(
+      mockRequest
+    );
+    expect(response).toEqual(
+      left({
+        apply: expect.any(Function),
+        detail: expect.any(String),
+        kind: "IResponseErrorValidation"
+      })
+    );
+  });
+
+  it("should return a unauthorized if the JWT token is invalid ", async () => {
+    mockHeader.mockImplementationOnce(() => anInvalidSupportToken);
+    const response = await RequestCitizenToFiscalCode(aPublicRsaCert)(
+      mockRequest
+    );
+    expect(response).toEqual(
+      left({
+        apply: expect.any(Function),
+        detail: expect.any(String),
+        kind: "IResponseErrorForbiddenNotAuthorized"
+      })
+    );
+  });
+});

--- a/utils/middleware/citizen_id.ts
+++ b/utils/middleware/citizen_id.ts
@@ -31,22 +31,15 @@ export const RequestCitizenToFiscalCode = (
   FiscalCode
 > => async request => {
   return (
-    taskEither
-      .of<
-        IResponseErrorValidation | IResponseErrorForbiddenNotAuthorized,
-        void
-      >(void 0)
-      // validate the header is present and its value is in the correct shape
-      .chain(_ =>
-        tryCatch(
-          () => RequiredHeaderMiddleware(headerName, CitizenID)(request),
-          e =>
-            ResponseErrorValidation(
-              `Invalid ${headerName} header`,
-              toError(e).message
-            )
-        )
-      )
+    // validate the header is present and its value is in the correct shape
+    tryCatch(
+      () => RequiredHeaderMiddleware(headerName, CitizenID)(request),
+      e =>
+        ResponseErrorValidation(
+          `Invalid ${headerName} header`,
+          toError(e).message
+        ) as IResponseErrorValidation | IResponseErrorForbiddenNotAuthorized
+    )
       .chain(fromEither)
       // validate the value is either a fiscal code or a valid JWT. In the latter case, the fiscal code is resolved
       .chain(c =>

--- a/utils/middleware/citizen_id.ts
+++ b/utils/middleware/citizen_id.ts
@@ -1,0 +1,59 @@
+import { toError } from "fp-ts/lib/Either";
+import { fromEither, taskEither, tryCatch } from "fp-ts/lib/TaskEither";
+import { IRequestMiddleware } from "io-functions-commons/dist/src/utils/request_middleware";
+import {
+  IResponseErrorForbiddenNotAuthorized,
+  IResponseErrorValidation,
+  ResponseErrorForbiddenNotAuthorized,
+  ResponseErrorValidation
+} from "italia-ts-commons/lib/responses";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+import { CitizenID } from "../../generated/definitions/CitizenID";
+import { withCitizenIdCheck } from "../citizen_id";
+import { RequiredHeaderMiddleware } from "./required_header";
+
+/**
+ * Perform validation on an incoming request assuring that
+ * - a CitizenID header is provided in the correct format
+ * - the CitizenID is a valid JWT
+ * - the CitizenID value is resolved into a valid FiscalCode
+ *
+ * @param publicRsaCertificate RSA certificate to validate JWT signature
+ * @param headerName (optional) the header in which we expect the value, default: "x-citizen-id"
+ *
+ * @returns Either the resolved fiscal code or a proper error
+ */
+export const RequestCitizenToFiscalCode = (
+  publicRsaCertificate: NonEmptyString,
+  headerName = "x-citizen-id"
+): IRequestMiddleware<
+  "IResponseErrorValidation" | "IResponseErrorForbiddenNotAuthorized",
+  FiscalCode
+> => async request => {
+  return (
+    taskEither
+      .of<
+        IResponseErrorValidation | IResponseErrorForbiddenNotAuthorized,
+        void
+      >(void 0)
+      // validate the header is present and its value is in the correct shape
+      .chain(_ =>
+        tryCatch(
+          () => RequiredHeaderMiddleware(headerName, CitizenID)(request),
+          e =>
+            ResponseErrorValidation(
+              `Invalid ${headerName} header`,
+              toError(e).message
+            )
+        )
+      )
+      .chain(fromEither)
+      // validate the value is either a fiscal code or a valid JWT. In the latter case, the fiscal code is resolved
+      .chain(c =>
+        withCitizenIdCheck(c, publicRsaCertificate, fiscalCode =>
+          taskEither.of(fiscalCode)
+        ).mapLeft(_ => ResponseErrorForbiddenNotAuthorized)
+      )
+      .run()
+  );
+};


### PR DESCRIPTION
Every API call must logs on a Table Storage a set of information:
- `AuthLevel` Admin or Support
- `Citizen` the citizen `fiscalCode` owner of the information
- `OperationName` the name of the function called
- `PartitionKey` the user identifier that executes the API call
- `RowKey` a unique identifier, in this PR is proposed the Context `invocationId`
- `Timestamp` when the operation happens