### PR TITLE
[#175745056] Fix certificate permission for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,6 @@ services:
       POSTGRES_USER: testuser
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: test
-    volumes:
-      - ./docker/postgres/server.crt:/var/lib/postgresql/server.crt:delegated
-      - ./docker/postgres/server.key:/var/lib/postgresql/server.key:delegated
 
 networks:
   io-fn:

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,1 +1,7 @@
 FROM postgres:13
+
+COPY ./docker/postgres/server.crt /var/lib/postgresql/server.crt
+COPY ./docker/postgres/server.key /var/lib/postgresql/server.key
+
+RUN chmod 600 /var/lib/postgresql/server.*
+RUN chown postgres /var/lib/postgresql/server.*


### PR DESCRIPTION
Setting the right permissions for `server.crt` and `server.key` inside postgres Docker image.