### PR TITLE
[#175740454] Fix paymentMethod mapping on toApiBPDCitizen

### DIFF
--- a/GetBPDCitizen/__tests__/handler.test.ts
+++ b/GetBPDCitizen/__tests__/handler.test.ts
@@ -49,7 +49,11 @@ const aSuccessCase = (citizenId: CitizenID) =>
           fiscal_code: aFiscalCode,
           payment_instrument_hpan:
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          payment_instrument_insert_date: aTimestamp,
+          payment_instrument_insert_user: "An user",
           payment_instrument_status: "ACTIVE",
+          payment_instrument_update_date: aTimestamp,
+          payment_instrument_update_user: "An user",
           timestamp_tc: aTimestamp
         },
         {

--- a/models/citizen.ts
+++ b/models/citizen.ts
@@ -1,16 +1,7 @@
 // tslint:disable: member-access variable-name
-import * as t from "io-ts";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
-import { enumType } from "italia-ts-commons/lib/types";
 import { AfterLoad, ViewColumn, ViewEntity } from "typeorm";
-
-export enum StatusEnum {
-  "ACTIVE" = "ACTIVE",
-  "INACTIVE" = "INACTIVE"
-}
-
-export const Status = enumType<StatusEnum>(StatusEnum, "status");
-export type Status = t.TypeOf<typeof Status>;
+import { Payment_instrument_statusEnum } from "../generated/definitions/PaymentMethod";
 
 @ViewEntity("v_bpd_citizen")
 export class Citizen {
@@ -67,7 +58,7 @@ export class Citizen {
   @ViewColumn({
     name: "status_c"
   })
-  payment_instrument_status?: Status;
+  payment_instrument_status?: Payment_instrument_statusEnum;
 
   @ViewColumn({
     name: "pay_istr_insert_date_t"


### PR DESCRIPTION
The new field `payment_instrument_insert_date` and `payment_instrument_update_date` must be mapped from `Date` to `string`. Cannot be used anymore the `PaymentMethod.is` to discriminate users record whidout any card.