### PR TITLE
[#175893555] Fix SupportToken regex

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -146,7 +146,7 @@ definitions:
       - payment_instrument_status
   SupportToken:
     type: string
-    pattern: "^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$"
+    pattern: "^[A-Za-z0-9-_=]+[.][A-Za-z0-9-_=]+[.][A-Za-z0-9-_.+/=]*$"
     description: A JWT token used by Support Team
   CitizenID:
     description: Fiscal Code or Support Token for Citizen Identification


### PR DESCRIPTION
`io-utils` cannot handle the escaping of dot character. We use an alternative `[.]` notation