### PR TITLE
[#175555319] Transaction descriptions as enums

### DIFF
--- a/GetBPDTransactions/__tests__/handler.test.ts
+++ b/GetBPDTransactions/__tests__/handler.test.ts
@@ -23,7 +23,9 @@ const mockTransactionRepository = taskEither.of<Error, Repository<Transaction>>(
 );
 
 const aFiscalCode = "AAABBB01C02D345D" as FiscalCode;
-const anAcquirer = "Acquirer1";
+const anAcquirer = "32875";
+const aCircuitType = "01";
+const aOperationType = "00";
 const aTimestamp = new Date();
 
 const anAuthenticatedUser: AdUser = {
@@ -48,18 +50,22 @@ describe("GetBPDTransactionsHandler", () => {
       return [
         {
           acquirer: anAcquirer,
+          circuit_type: aCircuitType,
           fiscal_code: aFiscalCode,
           hpan:
             "55ad015a3bf4f1b2b0b822cd15d6c15b0f00a089f86d081884c7d659a2feaa0c",
           id_trx_acquirer: "123456789012",
+          operation_type: aOperationType,
           trx_timestamp: aTimestamp
         },
         {
           acquirer: anAcquirer,
+          circuit_type: aCircuitType,
           fiscal_code: aFiscalCode,
           hpan:
             "0b822cd15d6c15b0f00a089f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b",
           id_trx_acquirer: "123456789013",
+          operation_type: aOperationType,
           trx_timestamp: aTimestamp
         }
         // tslint:disable-next-line: readonly-array

--- a/docker/fixtures/dump.pgsql
+++ b/docker/fixtures/dump.pgsql
@@ -183,8 +183,9 @@ INSERT INTO public.bpd_payment_instrument (hpan_s, fiscal_code_s, cancellation_t
 -- Data for Name: bpd_winning_transaction; Type: TABLE DATA; Schema: public; Owner: testuser
 --
 
-INSERT INTO public.bpd_winning_transaction VALUES ('Acquirer1', 'EUR', 10, NULL, NULL, '807ae5f38db47bff8b09b37ad803cb10ef5147567a89a33a66bb3282df4ad966', '1234567890123', NULL, NULL, NULL, 2, '2020-10-31 10:02:31.11989+00', '2020-10-31 10:02:31.11989+00', NULL, NULL, NULL, true, NULL, NULL, NULL, NULL, NULL, NULL);
-INSERT INTO public.bpd_winning_transaction VALUES ('Acquirer2', 'EUR', 31, NULL, NULL, '807ae5f38db47bff8b09b37ad803cb10ef5147567a89a33a66bb3282df4ad966', '2345678901555', NULL, NULL, NULL, 7, '2020-10-31 10:02:31.11989+00', '2020-10-31 10:02:31.11989+00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO public.bpd_winning_transaction VALUES ('32875', '978', 10, 0, "01", '807ae5f38db47bff8b09b37ad803cb10ef5147567a89a33a66bb3282df4ad966', '1234567890123', NULL, NULL, "00", 2, '2020-10-31 10:02:31.11989+00', '2020-10-31 10:02:31.11989+00', NULL, NULL, NULL, true, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO public.bpd_winning_transaction VALUES ('36081', '978', 31, 0, "01", '807ae5f38db47bff8b09b37ad803cb10ef5147567a89a33a66bb3282df4ad966', '2345678901555', NULL, NULL, "00", 7, '2020-10-31 10:02:31.11989+00', '2020-10-31 10:02:31.11989+00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO public.bpd_winning_transaction VALUES ('02008', '978', 31, 0, "00", '7726b99f6eff4f80f27e91eee2fb4f6e9f7aa01c5837cbc9f1b9dc4c51689a29', '2345678901555', NULL, NULL, "00", 7, '2020-10-31 10:02:31.11989+00', '2020-10-31 10:02:31.11989+00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 --
 -- Name: bpd_citizen bpd_citizen_pkey; Type: CONSTRAINT; Schema: public; Owner: testuser

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -177,6 +177,31 @@ definitions:
         type: string
       acquirer_descr:
         type: string
+        enum: [
+          Nexi,
+          IntesaSanPaolo,
+          Poste,
+          Unicredit,
+          BancaSella,
+          Nexi_UBI,
+          Nexi_ICCREA,
+          AmericanExpress,
+          Satispay,
+          ICCREA,
+          Diners,
+          Axepta_BNP,
+          SumUP,
+          Bancomat,
+          BancomatPay,
+          SiaPay,
+          Paytipper,
+          Reiffeisen,
+          Cedacri,
+          Deutsche,
+          MPS,
+          EquensWorldline,
+          Other
+        ]
       id_trx_acquirer:
         type: string
       id_trx_issuer:
@@ -185,10 +210,31 @@ definitions:
         type: string
       operation_type_descr:
         type: string
+        enum: [
+          Payment,
+          Transfer,
+          ApplePay,
+          GooglePay,
+          Other
+        ]
       circuit_type:
         type: string
       circuit_type_descr:
         type: string
+        enum: [
+          Pagobancomat,
+          Visa,
+          Mastercard,
+          Amex,
+          JCB,
+          UnionPay,
+          Diners,
+          Codice_PostePay,
+          BancomatPay,
+          SatisPay,
+          Circuito_Privativo,
+          Other
+        ]
       amount:
         type: number
       amount_currency:

--- a/utils/conversion.ts
+++ b/utils/conversion.ts
@@ -1,0 +1,84 @@
+import {
+  Acquirer_descrEnum as Acquirer,
+  Circuit_type_descrEnum as CircuitType,
+  Operation_type_descrEnum as OperationType
+} from "../generated/definitions/BPDTransaction";
+
+export function getOperationType(operationType: string): OperationType {
+  switch (operationType) {
+    case "00":
+      return OperationType.Payment;
+    case "01":
+      return OperationType.Transfer;
+    case "02":
+      return OperationType.ApplePay;
+    case "03":
+      return OperationType.GooglePay;
+    default:
+      return OperationType.Other;
+  }
+}
+
+export function getCircuitType(circuitType: string): CircuitType {
+  switch (circuitType) {
+    case "00":
+      return CircuitType.Pagobancomat;
+    case "01":
+      return CircuitType.Visa;
+    case "02":
+      return CircuitType.Mastercard;
+    case "03":
+      return CircuitType.Amex;
+    case "04":
+      return CircuitType.JCB;
+    case "05":
+      return CircuitType.UnionPay;
+    case "06":
+      return CircuitType.Diners;
+    case "07":
+      return CircuitType.Codice_PostePay;
+    case "08":
+      return CircuitType.BancomatPay;
+    case "09":
+      return CircuitType.SatisPay;
+    case "10":
+      return CircuitType.Circuito_Privativo;
+    default:
+      return CircuitType.Other;
+  }
+}
+
+export function getAcquirer(acquirer: string): Acquirer {
+  switch (acquirer) {
+    case "32875":
+      return Acquirer.Nexi;
+    case "03069":
+      return Acquirer.IntesaSanPaolo;
+    case "36081":
+      return Acquirer.Poste;
+    case "02008":
+      return Acquirer.Unicredit;
+    case "03268":
+      return Acquirer.BancaSella;
+    case "03111":
+      return Acquirer.Nexi_UBI;
+    case "08000":
+      return Acquirer.Nexi_ICCREA;
+    case "36019":
+      return Acquirer.AmericanExpress;
+    case "STPAY":
+      return Acquirer.Satispay;
+    case "12940":
+      return Acquirer.ICCREA;
+    case "01005":
+      return Acquirer.Axepta_BNP;
+    case "COBAN":
+      return Acquirer.Bancomat;
+    case "BPAY1":
+      return Acquirer.BancomatPay;
+    case "33604":
+      return Acquirer.SiaPay;
+    default:
+      return Acquirer.Other;
+  }
+}


### PR DESCRIPTION
The fields `acquirer_descr`, `operation_type_descr` and `circuit_type_descr` are enums and their values are calculated from the original fields from the database (`acquirer`, `operation_type` and `circuit_type`)