### PR TITLE
[#176881861] Add anonymous to info api

### DIFF
--- a/Info/function.json
+++ b/Info/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",


### PR DESCRIPTION
This PR change `authLevel` to `anonymous` for Info api. This is an internal convention for all Info endpoints.

All info apis need to be anonymous, to be called with application insights web test without expose function's keys.

Here an example https://github.com/pagopa/io-infrastructure-live-new/pull/433#discussion_r573522015